### PR TITLE
Removiendo nav de base.html

### DIFF
--- a/app/views/base.html
+++ b/app/views/base.html
@@ -8,7 +8,6 @@
 </head>
 <body>
     <header>{% block header %}{% endblock %}</header>
-    <nav>{% block nav %}{% endblock %}</nav>
     <main>{% block main %}{% endblock %}</main>
     <footer>{% block footer %}{% endblock %}</footer>
 </body>

--- a/app/views/partials/nav.html
+++ b/app/views/partials/nav.html
@@ -1,4 +1,4 @@
-{% block nav %}
+<nav>
     <ul>
         <li><a href="/">Home</a></li>
         <li><a href="/about">About</a></li>
@@ -9,4 +9,4 @@
             <li><a href="/tasks/create">Create Tasks</a></li>
         </ul>
     </ul>
-{% endblock %}
+</nav>


### PR DESCRIPTION
Removí  

```html
<nav>{% block nav %}{% endblock %}</nav>
```

de este archivo `app/views/base.html` porque se esta renderizando adentro de `header` en los demas archivos `html`. Eso provoca que el `nav` quede vacio y que estos elementos:

```html
    <ul>
        <li><a href="/">Home</a></li>
        <li><a href="/about">About</a></li>
        <li><a href="/contact">Contact</a></li>
        <li><a href="/users">Manage Users</a></li>
        <li><a href="/tasks">Show Tasks</a></li>
        <ul>
            <li><a href="/tasks/create">Create Tasks</a></li>
        </ul>
    </ul>
```

se renderizen directamente adentro del tag header.